### PR TITLE
Disallow voting with negative coin amount

### DIFF
--- a/src/server/routes/bots.js
+++ b/src/server/routes/bots.js
@@ -124,7 +124,7 @@ router.get("/:id/vote", async (req, res) => {
       .then((d) => {
         if (d.err) return res.json({ err: "invalid_key" });
         if (!req.query.coins) return res.json({ err: "no_coins" });
-        if (req.query.coins <= 0) return res.json({ err: "coins_negative" })
+        if (req.query.coins <= 0) return res.json({ err: "negative_coins" })
         if (req.query.coins % 10 != 0)
           return res.json({ err: "coins_not_divisible" });
         const Vote = parseInt(req.query.coins) / 10;


### PR DESCRIPTION
Currently, voting with a negative coin amount allows you to take votes off a bot and give yourself coins.